### PR TITLE
workaround: inputs directly inline in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The `config` dictionary has the following options:
 | `numColumns` <br/><br/> default: `4` | Number of columns in the table. |
 | `rowsName` <br/><br/> default: `Row` | Name of rows in the table. |
 | `columnsName` <br/><br/> default: `Column` | Name of columns in the table. |
+| `canEditRowHeader` <br/><br/> default: `true` | Make the row headers an input field? |
+| `canEditColumnHeader` <br/><br/> default: `false` | Make the column headers an input field? |
 | `names` <br/><br/> default: `["Value", "Status"] ` | Array of the names for all fields in a cell. |
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |

--- a/data-table/__tests__/table.js
+++ b/data-table/__tests__/table.js
@@ -101,6 +101,95 @@ describe('basic tests to ensure the buttons can function well', () => {
     });
 });
 
+describe('ensure row and columns can be independently set to editable', () => {
+    function childInColHeaderCell(col) {
+        const cell = document.getElementById(`_theadId_div-id__row_0_and_col_${col}_`);
+        if (cell == null) {
+            return null;
+        }
+        return cell.children[0];
+    }
+    function childInRowHeaderCell(row) {
+        const cell = document.getElementById(`div-id_row_${row}_and_col_0_`);
+        if (cell == null) {
+            return null;
+        }
+        return cell.children[0];
+    }
+    test('Ensure inputs exist on both row and col', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id',
+            'canEditRowHeader': true,
+            'canEditColumnHeader': true
+        });
+
+        expect(childInRowHeaderCell(1).tagName).toEqual('INPUT');
+        expect(childInColHeaderCell(1).tagName).toEqual('INPUT');
+    });
+    test('Ensure inputs exist on only row', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id',
+            'canEditRowHeader': true,
+            'canEditColumnHeader': false
+        });
+
+        expect(childInRowHeaderCell(1).tagName).toEqual('INPUT');
+        expect(childInColHeaderCell(1)).toEqual(undefined);
+    });
+    test('Ensure inputs exist on only col', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id',
+            'canEditRowHeader': false,
+            'canEditColumnHeader': true
+        });
+
+        expect(childInRowHeaderCell(1)).toEqual(undefined);
+        expect(childInColHeaderCell(1).tagName).toEqual('INPUT');
+    });
+    test('Ensure defaults are row only', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id'
+        });
+
+        expect(childInRowHeaderCell(1).tagName).toEqual('INPUT');
+        expect(childInColHeaderCell(1)).toEqual(undefined);
+    });
+    test('Ensure add col also adds an input', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id',
+            'canEditRowHeader': true,
+            'canEditColumnHeader': true
+        });
+
+        const leftButtons = document.getElementsByClassName("left-panel-button");
+        const addColButton = leftButtons[0];
+
+        // Doesn't exist before button click
+        expect(childInColHeaderCell(4)).toEqual(null);
+
+        // Does exist after
+        addColButton.click();
+        expect(childInColHeaderCell(4).tagName).toEqual('INPUT');
+    });
+    test('Ensure add row also adds an input', () => {
+        table.createDataTable({
+            'wrapperDivId': 'div-id',
+            'canEditRowHeader': true,
+            'canEditColumnHeader': true
+        });
+
+        const leftButtons = document.getElementsByClassName("left-panel-button");
+        const addColButton = leftButtons[2];
+
+        // Doesn't exist before button click
+        expect(childInRowHeaderCell(4)).toEqual(null);
+
+        // Does exist after
+        addColButton.click();
+        expect(childInRowHeaderCell(4).tagName).toEqual('INPUT');
+    });
+});
+
 describe('wrapperDivId config', () => {
     test('Passing invalid div', () => {
         expect(() => {

--- a/data-table/table.css
+++ b/data-table/table.css
@@ -32,11 +32,9 @@ body {
   margin: 1px 0;
 }
 .data-table{
-  position: absolute;
   width: 659px;
   height: 228px;
-  left: 421px;
-  top: 188px;
+  margin-top: 30px;
   background: #FFFFFF;
   border: 1px solid #000000;
   box-sizing: border-box;

--- a/data-table/table.js
+++ b/data-table/table.js
@@ -36,8 +36,8 @@ class Config {
         this.rowsNamePlural = this.rowsName + "s";
         this.columnsNamePlural = this.columnsName + "s";
         this.wrapperDivId = clientConfig.wrapperDivId;
-        this.canEditRowHeader = true;
-        this.canEditColumnHeader = false;
+        this.canEditRowHeader = clientConfig.canEditRowHeader === undefined ? true : clientConfig.canEditRowHeader;
+        this.canEditColumnHeader = clientConfig.canEditColumnHeader === undefined ? false : clientConfig.canEditColumnHeader;
 
         /**
          * @property {string} tableDivId        - ID for the div containing the table

--- a/docs/readme-generator.md
+++ b/docs/readme-generator.md
@@ -58,6 +58,8 @@ The `config` dictionary has the following options:
 | `numColumns` <br/><br/> default: `4` | Number of columns in the table. |
 | `rowsName` <br/><br/> default: `Row` | Name of rows in the table. |
 | `columnsName` <br/><br/> default: `Column` | Name of columns in the table. |
+| `canEditRowHeader` <br/><br/> default: `true` | Make the row headers an input field? |
+| `canEditColumnHeader` <br/><br/> default: `false` | Make the column headers an input field? |
 | `names` <br/><br/> default: `["Value", "Status"] ` | Array of the names for all fields in a cell. |
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |

--- a/index.md
+++ b/index.md
@@ -65,6 +65,8 @@ The `config` dictionary has the following options:
 | `numColumns` <br/><br/> default: `4` | Number of columns in the table. |
 | `rowsName` <br/><br/> default: `Row` | Name of rows in the table. |
 | `columnsName` <br/><br/> default: `Column` | Name of columns in the table. |
+| `canEditRowHeader` <br/><br/> default: `true` | Make the row headers an input field? |
+| `canEditColumnHeader` <br/><br/> default: `false` | Make the column headers an input field? |
 | `names` <br/><br/> default: `["Value", "Status"] ` | Array of the names for all fields in a cell. |
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/537316/143298990-d0e1957d-3df8-443c-8310-e8c17304af38.png)
![image](https://user-images.githubusercontent.com/537316/143299072-fd0fb406-ffd6-440a-a83b-9940051aa66c.png)


A workaround for now: get the inputs working for an RCVis demo soon. Needs test.