### PR TITLE
Standardize css names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ The `config` dictionary has the following options:
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |
 | `callbacks` <br/><br/> default: `"None"` | Tells what function to execute when a field is changed. |
+
+## CSS configuration
+All CSS styles begin with `dt_` and can be overridden with your own custom CSS.
+See [data-table/table.css](data-table/table.css) for some of the options that may be overridden.
+Additional, unstyled classes are also set on several elements, though these are undocumented.

--- a/data-table/__tests__/table.js
+++ b/data-table/__tests__/table.js
@@ -31,12 +31,12 @@ describe('basic tests to ensure createDataTable can function well', () => {
     });
 
     test('properly test the first cell', () => {
-        const contents = document.getElementsByClassName('data-table-cell')[0].textContent;
+        const contents = document.getElementsByClassName('dt_cell')[0].textContent;
         expect(contents).toEqual('Rows');
     });
 
     test('properly test the first cell', () => {
-        const contents = document.getElementsByClassName('data-table-cell')[1].textContent;
+        const contents = document.getElementsByClassName('dt_cell')[1].textContent;
         expect(contents).toEqual('Column 1');
     });
 
@@ -59,44 +59,44 @@ describe('basic tests to ensure the buttons can function well', () => {
     test('check the add column button fuctionality', () => {
         const numRows = 4;
         const numCols = 4;
-        const addButton = document.getElementsByClassName("left-panel-button");
-        let contents = document.getElementsByClassName("data-table-cell");
+        const addButton = document.getElementsByClassName("dt_left-panel-button");
+        let contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * numCols);
         addButton[0].click();
-        contents = document.getElementsByClassName("data-table-cell");
+        contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * (numCols + 1));
     });
 
     test('check the delete column button fuctionality', () => {
         const numRows = 4;
         const numCols = 4;
-        const addButton = document.getElementsByClassName("left-panel-button");
-        let contents = document.getElementsByClassName("data-table-cell");
+        const addButton = document.getElementsByClassName("dt_left-panel-button");
+        let contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * numCols);
         addButton[1].click();
-        contents = document.getElementsByClassName("data-table-cell");
+        contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * (numCols - 1));
     });
 
     test('check the add a row button fuctionality', () => {
         const numRows = 4;
         const numCols = 4;
-        const addButton = document.getElementsByClassName("left-panel-button");
-        let contents = document.getElementsByClassName("data-table-cell");
+        const addButton = document.getElementsByClassName("dt_left-panel-button");
+        let contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * numCols);
         addButton[2].click();
-        contents = document.getElementsByClassName("data-table-cell");
+        contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual((numRows+1) * numCols);
     });
 
     test('check the delete a row button fuctionality', () => {
         const numRows = 4;
         const numCols = 4;
-        const addButton = document.getElementsByClassName("left-panel-button");
-        let contents = document.getElementsByClassName("data-table-cell");
+        const addButton = document.getElementsByClassName("dt_left-panel-button");
+        let contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * numCols);
         addButton[3].click();
-        contents = document.getElementsByClassName("data-table-cell");
+        contents = document.getElementsByClassName("dt_cell");
         expect(contents.length).toEqual(numRows * (numCols-1));
     });
 });
@@ -161,7 +161,7 @@ describe('ensure row and columns can be independently set to editable', () => {
             'canEditColumnHeader': true
         });
 
-        const leftButtons = document.getElementsByClassName("left-panel-button");
+        const leftButtons = document.getElementsByClassName("dt_left-panel-button");
         const addColButton = leftButtons[0];
 
         // Doesn't exist before button click
@@ -178,7 +178,7 @@ describe('ensure row and columns can be independently set to editable', () => {
             'canEditColumnHeader': true
         });
 
-        const leftButtons = document.getElementsByClassName("left-panel-button");
+        const leftButtons = document.getElementsByClassName("dt_left-panel-button");
         const addColButton = leftButtons[2];
 
         // Doesn't exist before button click
@@ -262,12 +262,12 @@ describe('API basic tests', () => {
     });
 
     test('properly create default input field within each cell', () => {
-        let inputList = cellFieldList('cell-input');
+        let inputList = cellFieldList('dt_cell-input');
         expect(inputList.length).toEqual(9);
     });
 
     test('properly create default dropdown field within each cell', () => {
-        let dropdownList = cellFieldList('cell-dropdown');
+        let dropdownList = cellFieldList('dt_cell-dropdown');
         expect(dropdownList.length).toEqual(9);
     });
 
@@ -278,12 +278,12 @@ describe('API basic tests', () => {
             'types': [Boolean],
             'values': [false]
         });
-        let checkboxList = cellFieldList('cell-checkbox');
+        let checkboxList = cellFieldList('dt_cell-checkbox');
         expect(checkboxList.length).toEqual(9);
     });
 
     test('properly create checkbox field within each cell', () => {
-        let dropdownList = cellFieldList('cell-dropdown');
+        let dropdownList = cellFieldList('dt_cell-dropdown');
         for (let i = 0; i < 9; i++) {
             let res = dropdownList[i].options[0].text;
             expect(res).toBe("Active");
@@ -291,7 +291,7 @@ describe('API basic tests', () => {
     });
 
     test('properly test how many options for the dropdown filed', () => {
-        let dropdownList = cellFieldList('cell-dropdown');
+        let dropdownList = cellFieldList('dt_cell-dropdown');
         for (let i = 0; i < 9; i++) {
             let res = dropdownList[i].options.length;
             expect(res).toBe(2);
@@ -299,7 +299,7 @@ describe('API basic tests', () => {
     });
 
     test('properly create checkbox field within each cell', () => {
-        let inputList = cellFieldList('cell-input');
+        let inputList = cellFieldList('dt_cell-input');
         expect(inputList[0].getAttribute("placeholder")).toEqual("0");
     });
 
@@ -356,17 +356,17 @@ describe('Interaction tests', () => {
         createSingleCellTable(['Value'], [Number], [0], [invalidIfNegative])
         expect(numErrorsVisible()).toEqual(0);
 
-        let input = document.getElementsByClassName('cell-input')[0];
+        let input = document.getElementsByClassName('dt_cell-input')[0];
         input.value = -23;
         input.dispatchEvent(new Event('focusout'));
 
-        expect(document.getElementsByClassName('invalid-cell').length).toEqual(1);
+        expect(document.getElementsByClassName('dt_invalid-cell').length).toEqual(1);
     });
 
     test('Valid input to text input field updates cell appropriately', () => {
         createSingleCellTable(['Value'], [Number], [0], [invalidIfNegative])
 
-        let input = document.getElementsByClassName('cell-input')[0];
+        let input = document.getElementsByClassName('dt_cell-input')[0];
         input.value = -23;
         input.dispatchEvent(new Event('focusout'));
         input.value = 23;

--- a/data-table/table.css
+++ b/data-table/table.css
@@ -1,8 +1,4 @@
-body {
-    background-color: white;
-}
-
-.table-entry-field{
+.dt_table-entry-field{
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -17,7 +13,7 @@ body {
   border-radius: 8px;
 }
 
-.left-panel-button{
+.dt_left-panel-button{
   min-width: 200px;
   height: 46px;
   background: #FFFFFF;
@@ -31,7 +27,8 @@ body {
   flex-grow: 0;
   margin: 1px 0;
 }
-.data-table{
+
+.dt_inner-table{
   width: 659px;
   height: 228px;
   margin-top: 30px;
@@ -41,63 +38,20 @@ body {
   border-collapse: collapse;
 }
 
-.data-table-cell{
+.dt_cell{
   padding: 15px;
   border-width: 1px;
   border-style: solid;
 }
 
-.row-header-input{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 12px 16px;
-
-    width: 150px;
-    height: 46px;
-
-    background: #FFFFFF;
-    border: 2px solid #D9D9D9;
-    box-sizing: border-box;
-    border-radius: 8px;
-}
-
-.cell-input{
-    display: inline-block;
-    flex-direction: row;
-    align-items: center;
-    padding: 12px 2px;
-
-    width: 75px;
-    height: 25px;
-
-    background: #FFFFFF;
-    border: 2px solid #D9D9D9;
-    box-sizing: border-box;
-    border-radius: 8px;
-}
-
-.invalid-cell{
-  padding: 15px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: darkred;
-  background-color: #FF7F7F;
-}
-
-.error-message{
-  word-wrap: normal;
-  color: darkred;
-}
-
-.row-header-input{
-  display: flex;
+.dt_cell-input{
+  display: inline-block;
   flex-direction: row;
   align-items: center;
-  padding: 12px 16px;
+  padding: 12px 2px;
 
-  width: 150px;
-  height: 46px;
+  width: 75px;
+  height: 25px;
 
   background: #FFFFFF;
   border: 2px solid #D9D9D9;
@@ -105,12 +59,24 @@ body {
   border-radius: 8px;
 }
 
-
-.cell-label{
-    white-space: nowrap;
+.dt_invalid-cell{
+  padding: 15px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: darkred;
+  background-color: #FF7F7F;
 }
 
-.cell-label::after{
-    content: "\a";
-    white-space: pre;
+.dt_error-message{
+  word-wrap: normal;
+  color: darkred;
+}
+
+.dt_cell-label{
+  white-space: nowrap;
+}
+
+.dt_cell-label::after{
+  content: "\a";
+  white-space: pre;
 }

--- a/data-table/table.js
+++ b/data-table/table.js
@@ -156,15 +156,13 @@ function validateConfig(config) {
  * @returns {undefined}     - Doesn't return anything
  */
 function createSubDivs(config) {
-    let subDivClass = "SubDiv";
-
     let entryBoxDiv = document.createElement("div");
     entryBoxDiv.id = config.entryIds.entryBoxDivId;
-    entryBoxDiv.classList.add(subDivClass);
+    entryBoxDiv.classList.add("dt_left-panel");
 
     let tableDiv = document.createElement("div");
     tableDiv.id = config.tableIds.tableDivId;
-    tableDiv.classList.add(subDivClass);
+    entryBoxDiv.classList.add("dt_right-panel");
 
     document.getElementById(config.wrapperDivId).appendChild(entryBoxDiv);
     document.getElementById(config.wrapperDivId).appendChild(tableDiv);
@@ -178,7 +176,7 @@ function createSubDivs(config) {
 function createTable(config) {
     let table = document.createElement("table");
     table.id = config.tableIds.tableElementId;
-    table.classList.add("data-table");
+    table.classList.add("dt_inner-table");
 
     let thead = document.createElement("thead");
     thead.id = config.tableIds.theadElementId;
@@ -207,7 +205,7 @@ function createColumnHeader(config) {
         // Create an entry cell
         let cell = row.insertCell(colIndex);
         cell.id = cellIndexToElementId(config.tableIds.theadElementId, 0, colIndex)
-        cell.classList.add("data-table-cell");
+        cell.classList.add("dt_cell");
 
         cell.appendChild(createColumnHeaderCell(config, colIndex));
     }
@@ -229,7 +227,7 @@ function createColumnHeaderCell(config, colIndex) {
     let input = document.createElement("INPUT");
     input.type = 'text';
     input.placeholder = config.columnsName;
-    input.classList.add('table-entry-field');
+    input.classList.add('dt_table-entry-field');
     return input;
 }
 
@@ -243,7 +241,7 @@ function createRowHeaderCell(config, rowIndex) {
     let input = document.createElement("INPUT");
     input.type = 'text';
     input.placeholder = config.rowsName;
-    input.classList.add('table-entry-field');
+    input.classList.add('dt_table-entry-field');
     return input;
 }
 
@@ -255,7 +253,7 @@ function createRowHeaderCell(config, rowIndex) {
 function createLeftPanelButton(text) {
     let button = document.createElement("button");
     button.type = "button";
-    button.classList.add("left-panel-button");
+    button.classList.add("dt_left-panel-button");
     button.innerHTML = text;
     return button;
 }
@@ -274,7 +272,7 @@ function addSingleColumn(config) {
 
     let cell = table.rows[0].insertCell(numCols);
     cell.id = cellIndexToElementId(config.tableIds.theadElementId, 0, numCols);
-    cell.classList.add("data-table-cell");
+    cell.classList.add("dt_cell");
 
     cell.appendChild(createColumnHeaderCell(config, numCols));
 
@@ -329,7 +327,7 @@ function addSingleRow(config) {
 function createRowHeader(config, row, rowIndex, colIndex) {
     let cell = row.insertCell(colIndex);
     cell.id = cellIndexToElementId(config.wrapperDivId, rowIndex, colIndex)
-    cell.classList.add("data-table-cell");
+    cell.classList.add("dt_cell");
     cell.appendChild(createRowHeaderCell(config, rowIndex));
 }
 
@@ -344,32 +342,32 @@ function createRowHeader(config, row, rowIndex, colIndex) {
 function createEntryCell(config, row, rowIndex, colIndex) {
     let cell = row.insertCell(colIndex);
     cell.id = cellIndexToElementId(config.wrapperDivId, rowIndex, colIndex)
-    cell.classList.add("data-table-cell");
+    cell.classList.add("dt_cell");
     // add all the stuff from datumConfig
     for (let fieldNum = 0; fieldNum < config.datumConfig.names.length; fieldNum++) {
         let type = config.datumConfig.types[fieldNum];
 
         let label = document.createElement("LABEL");
         label.innerHTML = config.datumConfig.names[fieldNum] + ": ";
-        label.classList.add('cell-label');
+        label.classList.add('dt_cell-label');
 
         let field = null;
         if (type === Number || type === String) {
             let input = document.createElement("INPUT");
             input.type = 'text';
             input.placeholder = config.datumConfig.values[fieldNum];
-            input.classList.add('cell-input');
+            input.classList.add('dt_cell-input');
             field = input;
         } else if (type === Boolean) {
             let input = document.createElement("INPUT");
             input.type = 'checkbox';
-            input.classList.add('cell-checkbox');
+            input.classList.add('dt_cell-checkbox');
             input.defaultChecked = config.datumConfig.values[fieldNum];
             field = input;
         } else if (type === Array) {
             let select = document.createElement("select");
             select.type = 'dropdown';
-            select.classList.add('cell-dropdown');
+            select.classList.add('dt_cell-dropdown');
             for (let i = 0; i < config.datumConfig.values[fieldNum].length; i++) {
                 let option = document.createElement("option");
                 option.innerHTML = config.datumConfig.values[fieldNum][i];
@@ -453,18 +451,18 @@ function handleCallbackReturn(config, cell, fieldNum, callbackCode) {
         /**
          * FIXME: Instead of replacing this, have the invalid style be toggleable
          */
-        cell.classList.replace('data-table-cell', 'invalid-cell');
+        cell.classList.replace('dt_cell', 'dt_invalid-cell');
 
         // And then adds an error message to the bottom of the cell
         let errorMessage = document.createElement("P");
         errorMessage.innerHTML = ("Invalid " + config.datumConfig.names[fieldNum].toLowerCase());
-        errorMessage.classList.add('error-message');
+        errorMessage.classList.add('dt_error-message');
         errorMessage.id = errorStringId;
         cell.appendChild(errorMessage);
     } else {
         // If the field entry is no longer invalid, change cell back to normal and remove error message
-        if (cell.classList.contains('invalid-cell')) {
-            cell.classList.replace('invalid-cell', 'data-table-cell');
+        if (cell.classList.contains('dt_invalid-cell')) {
+            cell.classList.replace('dt_invalid-cell', 'dt_cell');
             cell.removeChild(document.getElementById(errorStringId));
         }
 

--- a/docs/readme-generator.md
+++ b/docs/readme-generator.md
@@ -64,3 +64,8 @@ The `config` dictionary has the following options:
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |
 | `callbacks` <br/><br/> default: `"None"` | Tells what function to execute when a field is changed. |
+
+## CSS configuration
+All CSS styles begin with `dt_` and can be overridden with your own custom CSS.
+See [data-table/table.css](data-table/table.css) for some of the options that may be overridden.
+Additional, unstyled classes are also set on several elements, though these are undocumented.

--- a/index.md
+++ b/index.md
@@ -71,3 +71,8 @@ The `config` dictionary has the following options:
 | `types` <br/><br/> default: `[Number, Array]` | Array of the types for all fields in a cell. |
 | `values` <br/><br/> default: `[0, ["Active", "Inactive"]]` | Array of the types for all fields in a cell. |
 | `callbacks` <br/><br/> default: `"None"` | Tells what function to execute when a field is changed. |
+
+## CSS configuration
+All CSS styles begin with `dt_` and can be overridden with your own custom CSS.
+See [data-table/table.css](data-table/table.css) for some of the options that may be overridden.
+Additional, unstyled classes are also set on several elements, though these are undocumented.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfca-data-table",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "data table test",
   "main": "data-table/table.js",
   "directories": {


### PR DESCRIPTION
1. To prevent this CSS file from overriding settings on the client's stylesheets, give it a "namespace" starting with `dt_`
2. Add documentation to match
3. Remove unused CSS