### PR TITLE
bugfix: focusout, focusin, focusout would render multiple errors

### DIFF
--- a/data-table/__tests__/table.js
+++ b/data-table/__tests__/table.js
@@ -384,6 +384,30 @@ describe('Interaction tests', () => {
         expect(numErrorsVisible()).toEqual(0);
     });
 
+    test('Allow multiple error messages per cell, one per field', () => {
+        createSingleCellTable(['Value0', 'Value1'], [Number, Number], [0, 0], [invalidIfNegative, invalidIfNegative])
+
+        let input0 = document.getElementsByClassName('dt_cell-input')[0];
+        let input1 = document.getElementsByClassName('dt_cell-input')[1];
+        input0.value = -23;
+        input0.dispatchEvent(new Event('focusout'));
+        input1.value = -23;
+        input1.dispatchEvent(new Event('focusout'));
+
+        expect(document.getElementsByClassName('dt_error-message')).toHaveLength(2);
+    });
+
+    test('Regression test: only one error message per field', () => {
+        createSingleCellTable(['Value'], [Number], [0], [invalidIfNegative])
+
+        let input = document.getElementsByClassName('dt_cell-input')[0];
+        input.value = -23;
+        input.dispatchEvent(new Event('focusout'));
+        input.dispatchEvent(new Event('focusout'));
+
+        expect(document.getElementsByClassName('dt_error-message')).toHaveLength(1);
+    });
+
     test('Ensure all buttons are non-submitting buttons', () => {
         createSingleCellTable(['Value'], [Number], [0], [invalidIfNegative])
 

--- a/data-table/table.js
+++ b/data-table/table.js
@@ -438,9 +438,6 @@ function createCallbackListener(config, cell, field, fieldNum) {
  * @returns {undefined}                     - Doesn't return anything
  */
 function handleCallbackReturn(config, cell, fieldNum, errorMessage) {
-    /**
-     * FIXME: Maybe we should be accepting an array of return "codes" to support multiple function calls?
-     */
     let errorStringId = cell.id + fieldNum + '_error_';
 
     if (errorMessage !== null && errorMessage !== undefined) {
@@ -450,12 +447,19 @@ function handleCallbackReturn(config, cell, fieldNum, errorMessage) {
          */
         cell.classList.replace('dt_cell', 'dt_invalid-cell');
 
-        // And then adds an error message to the bottom of the cell
-        let errorMessageElement = document.createElement("P");
+        // Try to find the existing error message to update
+        let errorMessageElement = document.getElementById(errorStringId);
+
+        // Create error message if it doesn't exist
+        if (errorMessageElement === null) {
+            errorMessageElement = document.createElement("P");
+            errorMessageElement.classList.add('dt_error-message');
+            errorMessageElement.id = errorStringId;
+            cell.appendChild(errorMessageElement);
+        }
+
+        // Update the text
         errorMessageElement.innerHTML = errorMessage;
-        errorMessageElement.classList.add('dt_error-message');
-        errorMessageElement.id = errorStringId;
-        cell.appendChild(errorMessageElement);
     } else if (cell.classList.contains('dt_invalid-cell')) {
         // If the field entry is no longer invalid, change cell back to normal and remove error message
         cell.classList.replace('dt_invalid-cell', 'dt_cell');


### PR DESCRIPTION
screenshot of the issue: 
![image](https://user-images.githubusercontent.com/537316/144140761-edbc1c08-f3fd-48e0-b936-e1aea5201b5d.png)


To reproduce:
1. Enter -5 on a field in https://brmighell.github.io/rcv-entry/
2. Tab out to next field
3. Tab back in
4. Tab back out

You could also never remove the extraneously added errors - they'd be stuck forever